### PR TITLE
Add cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ The Portlet War (__wp.War__) configuration item can be defined in a deployment p
 | -------- | ----------- |
 | portalAppName | Name for the portal application | 
 | portalAppUid | Unique identifier for the portal application as defined in the portal.xml |
-| portalAppConcreteUid | Concrete Unique identifier for the portal application as defined in the portal.xml. Only __required__ for __IBM-API__ type portlets |
+| portalAppConcreteUid | Concrete Unique identifier for the portal application as defined in the portlet.xml. Only __required__ for __IBM-API__ type portlets |
          
-### Defining portlet configuration items ###
+### Defining portlets ###
 
 The portlets that are contained in the War are described using the __wp.PortletSpec__ type. This type is a child of the __wp.War__
 
 | Property | Description | 
 | -------- | ----------- |
-| portletName | Name of the portlet as described in the portal.xml |
+| portletName | Name of the portlet as described in the portlet.xml |
 | uniqueName | Unique name for portlet. e.g. com.xebialabs.WelcomePortlet. _Optional_|
 | preferences |Preferences for the portlet described as a key value map. _Optional_. |
 | userAclMapping | See _access permissions_ below. _Optional_. |
 | groupAclMapping | See _access permissions_ below. _Optional_. |
 
-#### Access permissions ####
+### Access permissions ###
 Portlet access permissions can be defined under the __Security__ tab. The permission can be captured for a _user_ or _user\_group_ as a key value map. The _key_ being the desired security level. The _value_ should container the desired subject ids delimited by a pipe (\|).
 Valid security levels are, 
 
@@ -97,6 +97,35 @@ Valid security levels are,
 * delegator
 * security administrator
 * administrator
+
+### Defining portlet clones ###
+
+Portlets which need to be cloned can be specified using the __wp.PortletCloneSpec__ type. This type is a child of __wp.PortletSpec__.
+A clone of a portlet is an instance of a portlet with it's own name and specifications like preferences. Therefore it needs some propterties of which some are like a normal portlet.
+
+| Property | Description | 
+| -------- | ----------- |
+| cloneName | Name of the clone which will be appended to the original name. e.g. portletName=welcome-portlet and cloneName = clone1 makes name welcome-portlet.$cloned.clone1 |
+| uniqueName | Unique name for portlet. e.g. com.xebialabs.WelcomePortlet. _Optional_|
+| preferences |Preferences for the portlet described as a key value map. _Optional_. |
+| userAclMapping | See _access permissions_ above. _Optional_. |
+| groupAclMapping | See _access permissions_ above. _Optional_. |
+| defaultLocale | A default locale which describes the portlet. Needs to be in the localedata list |
+| localedata | See _Locale data_ below |
+
+### Locale data ###  
+
+A portlet Clone needs like name and description, this can be specified using the __wp.PortletCloneLocaleDataSpec__ type. This type is a child of __wp.PortletCloneSpec__.
+For portlets this is normally stated in the portlet.xml, but for clones this needs to be added, as it is probably different then the original portlet.
+One locale needs to be setup, and be referred as default locale for the clone. All other locales are optional.
+
+| Property | Description | 
+| -------- | ----------- |
+| locale | The locale. e.g. en |
+| title | Portlet title in specified locale. |
+| description | Portlet descriptions in specified locale. _Optional_. |
+| keywords | Portlet keywords in specified locale. _Optional_. |
+
 
 ### Sample _deployit-manifest.xml_ ###
 
@@ -122,6 +151,27 @@ Valid security levels are,
           <groupAclMapping>
             <entry key="user">all authenticated portal users</entry>
           </groupAclMapping>
+          <clones>
+          <wp.PortletCloneSpec name="WelcomePortlet.war/WelcomePortlet/clonespec1">
+            <cloneName>clone1</cloneName>
+            <preferences>
+              <entry key="apref">apref_value_for_clone</entry>
+            </preferences>
+            <defaultlocale>en</defaultlocale>
+            <localedata>
+              <wp.PortletCloneLocaleDataSpec name="WelcomePortlet.war/WelcomePortlet/clonespec1/en">
+                <locale>en</locale>
+                <title>Welcome Portlet Clone</title>
+              </wp.PortletCloneLocaleDataSpec>
+            </localedata>
+            <userAclMapping>
+              <entry key="user">anonymous portal user</entry>
+            </userAclMapping>
+            <groupAclMapping>
+              <entry key="user">all authenticated portal users</entry>
+            </groupAclMapping>
+          </wp.PortletCloneSpec>
+        </clones>
         </wp.PortletSpec>
       </portlets>
     </wp.War>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'xld-webspphere-portal-plugin'
+rootProject.name = 'xld-websphere-portal-plugin'

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -16,21 +16,68 @@
     <type type="wp.War" extends="was.War" description="JSR Portal WAR archive">
         <property name="portalAppName" label="Portal Application Name" description="Name for this portal application" category="Portal"/>
         <property name="portalAppUid" label="Portal Application Identifier"
-                  description="Unique identifier for this portal application as defined in the portal.xml" category="Portal"/>
+                  description="Unique identifier for this portal application as defined in the portlet.xml" category="Portal"/>
         <property name="portalAppConcreteUid" required="false" label="Concrete Portal Application Identifier"
-                  description="Required when deploying a IBM-API type portlet. Concrete Unique identifier for this portal application as defined in the portal.xml"
+                  description="Required when deploying a IBM-API type portlet. Concrete Unique identifier for this portal application as defined in the portlet.xml"
                   category="Portal"/>
         <property name="portlets" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletSpec" label="Portlets" category="Portal"
                   description="List of portlets to register."/>
     </type>
-
-    <!-- Deployeds -->
-    <type type="wp.Portlet" extends="udm.BaseEmbeddedDeployed" deployable-type="wp.PortletSpec" container-type="wp.WarModule" description="Deployed portlet to WebSphere Portal runtime.">
-        <generate-deployable type="wp.PortletSpec" extends="udm.BaseEmbeddedDeployable"/>
-
-        <property name="portletName" description="Name of the portlet as described in the portal.xml"/>
+    <type type="wp.PortletSpec" extends="udm.BaseEmbeddedDeployable" description="Portlet spec">
+        <property name="portletName" description="Name of the portlet (portlet-name) as described in the portlet.xml"/>
         <property name="uniqueName" description="Unique name for portlet" required="false"/>
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
+        <property name="clones" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneSpec" label="Clones" description="List of portlet clones to register."/>
+
+        <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+        <property name="groupAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of Group ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+    </type>
+    <type type="wp.PortletCloneSpec" extends="udm.BaseEmbeddedDeployable" description="Portlet clone spec">
+        <property name="cloneName" description="Name of the portlet clone"/>
+        <property name="uniqueName" description="Unique name for portlet" required="false"/>
+        <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
+        <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
+        <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleDataSpec" label="localedata" description="Locale data, one is mandetory and specified as default."/>
+
+        <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+        <property name="groupAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of Group ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+    </type>
+    <type type="wp.PortletCloneLocaleDataSpec" extends="udm.BaseEmbeddedDeployable" description="Portlet clone locale spec">
+        <property name="locale" description="locale of the name, description and keywords"/>
+        <property name="title" description="Portlet title in specified locale" required="true"/>
+        <property name="description" description="Portlet description in specified locale" required="false"/>
+        <property name="keywords" description="Portlet keywords in specified locale" required="false"/>
+    </type>
+
+    <!-- Deployeds -->
+    <type type="wp.WarModule" extends="was.WarModule" deployable-type="wp.War" container-type="was.WasAppContainer" description="WAR with values configured for a deployment.">
+        <property name="portalAppName" label="Portal Application Name" description="Name for this portal application" category="Portal"/>
+        <property name="portalAppUid" label="Portal Application Identifier" description="Unique identifier for this portal application as defined in the portlet.xml" category="Portal"/>
+        <property name="portalAppConcreteUid" required="false" label="Concrete Portal Application Identifier"
+                  description="Required when deploying a IBM-API type portlet. Concrete Unique identifier for this portal application as defined in the portlet.xml" category="Portal"/>
+        <property name="portlets" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.Portlet" label="Portlets" category="Portal" description="List of portlets to register."/>
+
+        <property name="modifyScript" hidden="true" required="false" default="was/portal/application/update-application.py"/>
+        <property name="warInstallLocationPrefix" hidden="true" required="false" default="file://localhost/"/>
+    </type>
+
+    <type type="wp.Portlet" extends="udm.BaseEmbeddedDeployed" deployable-type="wp.PortletSpec" container-type="wp.WarModule" description="Deployed portlet to WebSphere Portal runtime.">
+        <property name="portletName" description="Name of the portlet (portlet-name) as described in the portlet.xml"/>
+        <property name="uniqueName" description="Unique name for portlet" required="false"/>
+        <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
+        <property name="clones" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletClone" label="Clones" description="List of portlet clones to register."/>
 
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
@@ -44,15 +91,30 @@
         <property name="subjectDelimiter" hidden="true" default="|"/>
     </type>
 
-    <type type="wp.WarModule" extends="was.WarModule" deployable-type="wp.War" container-type="was.WasAppContainer" description="WAR with values configured for a deployment.">
-        <property name="portalAppName" label="Portal Application Name" description="Name for this portal application" category="Portal"/>
-        <property name="portalAppUid" label="Portal Application Identifier" description="Unique identifier for this portal application as defined in the portal.xml" category="Portal"/>
-        <property name="portalAppConcreteUid" required="false" label="Concrete Portal Application Identifier"
-                  description="Required when deploying a IBM-API type portlet. Concrete Unique identifier for this portal application as defined in the portal.xml" category="Portal"/>
-        <property name="portlets" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.Portlet" label="Portlets" category="Portal" description="List of portlets to register."/>
+    <type type="wp.PortletClone" extends="udm.BaseEmbeddedDeployed" deployable-type="wp.PortletCloneSpec" container-type="wp.Portlet" description="Deployed portlet clone to WebSphere Portal runtime.">
+        <property name="cloneName" description="Name of the portlet clone"/>
+        <property name="uniqueName" description="Unique name for portlet" required="false"/>
+        <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
+        <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
+        <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleData" label="localedata" description="Locale data, one is mandetory and specified as default."/>
 
-        <property name="modifyScript" hidden="true" required="false" default="was/portal/application/update-application.py"/>
-        <property name="warInstallLocationPrefix" hidden="true" required="false" default="file://localhost/"/>
+        <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+        <property name="groupAclMapping" kind="map_string_string" required="false" category="Security"
+                  description="List of Group ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
+            <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
+        </property>
+        <property name="securityLevels" hidden="true" kind="set_of_string" default="user,privileged user,contributor,editor,manager,delegator,security administrator,administrator"/>
+        <property name="subjectDelimiter" hidden="true" default="|"/>
+    </type>
+
+    <type type="wp.PortletCloneLocaleData" extends="udm.BaseEmbeddedDeployed" deployable-type="wp.PortletCloneLocaleDataSpec" container-type="wp.PortletClone" description="Locales to give the portlet clone name and description. One is always needed.">
+        <property name="locale" description="locale of the name, description and keywords"/>
+        <property name="title" description="Portlet title in specified locale" required="true"/>
+        <property name="description" description="Portlet description in specified locale" required="false"/>
+        <property name="keywords" description="Portlet keywords in specified locale" required="false"/>
     </type>
 
     <type type="wp.ExecutedXmlAccessInlineScriptPair" extends="udm.BaseDeployed" deployable-type="wp.XmlAccessInlineScriptPair" container-type="was.WasAppContainer"
@@ -77,6 +139,8 @@
         <property name="wpAdminUsername" label="Administrative user" description="Username of the administrative user." category="Portal" required="false"/>
         <property name="wpAdminPassword" label="Administrative password" description="Password of the administrative user." category="Portal" required="false" password="true"/>
         <property name="wpConfigUrl" label="Configuration URL" description="The URL of the WebSphere Portal configuration API." category="Portal" required="false"/>
+        <property name="portalHost" kind="ci" referenced-type="overthere.Host" label="Portal Host" description="The host xml access is on." category="Portal" required="true"/>
+        <property name="wpProfileLocation" label="Portal Profile Home" description="The location of the portal war file." category="Portal" required="false"/>         
         <property name="installedAppDir" default="installedApps" hidden="true" description="The install applications directory under the profile" category="Portal"/>
     </type-modification>
 

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -27,7 +27,7 @@
         <property name="portletName" description="Name of the portlet (portlet-name) as described in the portlet.xml"/>
         <property name="uniqueName" description="Unique name for portlet" required="false"/>
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
-        <property name="clones" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneSpec" label="Clones" description="List of portlet clones to register."/>
+        <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletCloneSpec" label="Clones" description="List of portlet clones to register."/>
 
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
@@ -77,7 +77,7 @@
         <property name="portletName" description="Name of the portlet (portlet-name) as described in the portlet.xml"/>
         <property name="uniqueName" description="Unique name for portlet" required="false"/>
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
-        <property name="clones" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletClone" label="Clones" description="List of portlet clones to register."/>
+        <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletClone" label="Clones" description="List of portlet clones to register."/>
 
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">

--- a/src/main/resources/was/portal/utils/xmlaccess.py
+++ b/src/main/resources/was/portal/utils/xmlaccess.py
@@ -289,7 +289,7 @@ class XmlAccess(object):
                     localedata_elm = ET.SubElement(portlet_clone_ci_elm, 'localedata', {'locale': localedata_ci.locale})
                     XmlAccess._add_text_elm(localedata_elm, 'title', localedata_ci.title)
                     XmlAccess._add_text_elm(localedata_elm, 'description', localedata_ci.description)
-                    XmlAccess._add_text_elm(localedata_elm, 'keywords', "${portlet.keywords}")
+                    XmlAccess._add_text_elm(localedata_elm, 'keywords', localedata_ci.keywords)
 
                 XmlAccess.add_unique_name_attr(portlet_clone_ci, portlet_clone_ci_elm)
                 XmlAccess.add_parameter_elems(portlet_clone_ci.preferences, [], portlet_clone_ci_elm)

--- a/src/main/resources/was/portal/utils/xmlaccess.py
+++ b/src/main/resources/was/portal/utils/xmlaccess.py
@@ -154,11 +154,12 @@ class XmlAccess(object):
     @staticmethod
     def add_parameter_elems(new_prefs, remove_prefs, portlet_elm):
         for pref_key, pref_val in new_prefs.items():
-            param_elm = ET.SubElement(portlet_elm, "parameter", {"name": pref_key, "type": "string", "update": "set"})
-            param_elm.text = pref_val
+            param_elm = ET.SubElement(portlet_elm, "preferences", {"name": pref_key, "update": "set"})
+            value_elm = ET.SubElement(param_elm, "value")
+            value_elm.text = pref_val
 
         for pref_key in remove_prefs:
-            ET.SubElement(portlet_elm, "parameter", {"name": pref_key, "type": "string", "update": "remove"})
+            ET.SubElement(portlet_elm, "preferences", {"name": pref_key, "update": "remove"})
 
     @staticmethod
     def add_unique_name_attr(portlet, portlet_elm):

--- a/src/main/resources/was/portal/utils/xmlaccess.py
+++ b/src/main/resources/was/portal/utils/xmlaccess.py
@@ -167,6 +167,24 @@ class XmlAccess(object):
             portlet_elm.set("uniquename", portlet.uniqueName)
 
     @staticmethod
+    def add_new_portlet_clones(portlet_app_elm, portlet_ci):
+        # Loop all portlet clones clones
+        for portlet_clone_ci in portlet_ci.clones:
+            portlet_clone_ci_elm = ET.SubElement(portlet_app_elm, 'portlet', {'action': "update", "active": "true", "defaultlocale": portlet_clone_ci.defaultlocale,
+                                                                              "name": portlet_ci.portletName + ".$cloned." + portlet_clone_ci.cloneName, "servletref": portlet_ci.portletName})
+
+            for localedata_ci in portlet_clone_ci.localedata:
+                # Add locale data
+                localedata_elm = ET.SubElement(portlet_clone_ci_elm, 'localedata', {'locale': localedata_ci.locale})
+                XmlAccess._add_text_elm(localedata_elm, 'title', localedata_ci.title)
+                XmlAccess._add_text_elm(localedata_elm, 'description', localedata_ci.description)
+                XmlAccess._add_text_elm(localedata_elm, 'keywords', localedata_ci.keywords)
+
+            XmlAccess.add_unique_name_attr(portlet_clone_ci, portlet_clone_ci_elm)
+            XmlAccess.add_parameter_elems(portlet_clone_ci.preferences, [], portlet_clone_ci_elm)
+            XmlAccess.add_access_control_elm(portlet_clone_ci, portlet_clone_ci_elm)
+
+    @staticmethod
     def generate_register_portlets_xml(deployed, war_installation_location):
         root = ET.fromstring(XmlAccess.REQUEST_XML)
         root.set("type", "update")
@@ -195,20 +213,7 @@ class XmlAccess(object):
             XmlAccess.add_parameter_elems(portlet_ci.preferences, [], portlet_elm)
             XmlAccess.add_access_control_elm(portlet_ci, portlet_elm)
 
-            # Loop all portlet clones clones
-            for portlet_clone_ci in portlet_ci.clones:
-                portlet_clone_ci_elm = ET.SubElement(portlet_app_elm, 'portlet', {'action': "update", "active": "true", "defaultlocale": portlet_clone_ci.defaultlocale, "name": portlet_ci.portletName + ".$cloned." + portlet_clone_ci.cloneName, "servletref": portlet_ci.portletName})
-
-                for localedata_ci in portlet_clone_ci.localedata:
-                    # Add locale data
-                    localedata_elm = ET.SubElement(portlet_clone_ci_elm, 'localedata', {'locale': localedata_ci.locale})
-                    XmlAccess._add_text_elm(localedata_elm, 'title', localedata_ci.title)
-                    XmlAccess._add_text_elm(localedata_elm, 'description', localedata_ci.description)
-                    XmlAccess._add_text_elm(localedata_elm, 'keywords', "${portlet.keywords}")
-
-                XmlAccess.add_unique_name_attr(portlet_clone_ci, portlet_clone_ci_elm)
-                XmlAccess.add_parameter_elems(portlet_clone_ci.preferences, [], portlet_clone_ci_elm)
-                XmlAccess.add_access_control_elm(portlet_clone_ci, portlet_clone_ci_elm)
+            XmlAccess.add_new_portlet_clones(portlet_app_elm, portlet_ci)
 
         return ET.tostring(root, encoding="UTF-8")
 
@@ -245,20 +250,7 @@ class XmlAccess(object):
             XmlAccess.add_parameter_elems(portlet_ci.preferences, [], portlet_elm)
             XmlAccess.add_access_control_elm(portlet_ci, portlet_elm)
 
-            # Loop all portlet clones clones
-            for portlet_clone_ci in portlet_ci.clones:
-                portlet_clone_ci_elm = ET.SubElement(portlet_app_elm, 'portlet', {'action': "update", "active": "true", "defaultlocale": portlet_clone_ci.defaultlocale, "name": portlet_ci.portletName + ".$cloned." + portlet_clone_ci.cloneName, "servletref": portlet_ci.portletName})
-
-                for localedata_ci in portlet_clone_ci.localedata:
-                    # Add locale data
-                    localedata_elm = ET.SubElement(portlet_clone_ci_elm, 'localedata', {'locale': localedata_ci.locale})
-                    XmlAccess._add_text_elm(localedata_elm, 'title', localedata_ci.title)
-                    XmlAccess._add_text_elm(localedata_elm, 'description', localedata_ci.description)
-                    XmlAccess._add_text_elm(localedata_elm, 'keywords', "${portlet.keywords}")
-
-                XmlAccess.add_unique_name_attr(portlet_clone_ci, portlet_clone_ci_elm)
-                XmlAccess.add_parameter_elems(portlet_clone_ci.preferences, [], portlet_clone_ci_elm)
-                XmlAccess.add_access_control_elm(portlet_clone_ci, portlet_clone_ci_elm)
+            XmlAccess.add_new_portlet_clones(portlet_app_elm, portlet_ci)
 
         # existing portlets
         for portlet_name in change_set.common_items:

--- a/src/main/resources/xl-rules.xml
+++ b/src/main/resources/xl-rules.xml
@@ -32,7 +32,7 @@
             <jython>
                 <description expression="true">"Register portlets contained in %s with %s" % (deployed.name, deployed.container.name)</description>
                 <script>was/portal/war/register-portlets-for-war.py</script>
-                <order>72</order>
+                <order>76</order>
             </jython>
         </steps>
     </rule>


### PR DESCRIPTION
Hi,

I've updated the plugin towards a higher PortalConfig.xsd so it still supports Portal 6.1 and higher. But adding the support for portlet cloning. Created specs for cloning as well in the synthetic.xml and changed the order for deploying a bit, so registration works on a clustered environment.

Also adapted the documentation to reflect this, and updated some wording here and there to make it more consistent.

Please review.

regards, Maarten