### PR TITLE
Add auth level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The portlets that are contained in the War are described using the __wp.PortletS
 | uniqueName | Unique name for portlet. e.g. com.xebialabs.WelcomePortlet. _Optional_|
 | preferences |Preferences for the portlet described as a key value map. _Optional_. |
 | clones | See _Defining portlet clones_ below. _Optional_. |
-| authLevel | The String representation of the associated auth level. Only used when step-up autentication is enabled. _Optional_. |
+| authLevel | The String representation of the associated auth level. Only used when step-up authentication is enabled. _Optional_. |
 | userAclMapping | See _access permissions_ below. _Optional_. |
 | groupAclMapping | See _access permissions_ below. _Optional_. |
 
@@ -113,7 +113,7 @@ A clone of a portlet is an instance of a portlet with it's own name and specific
 | preferences |Preferences for the portlet described as a key value map. _Optional_. |
 | defaultLocale | A default locale which describes the portlet. Needs to be in the localedata list |
 | localedata | See _Locale data_ below |
-| authLevel | The String representation of the associated auth level. Only used when step-up autentication is enabled. _Optional_. |
+| authLevel | The String representation of the associated auth level. Only used when step-up authentication is enabled. _Optional_. |
 | userAclMapping | See _access permissions_ above. _Optional_. |
 | groupAclMapping | See _access permissions_ above. _Optional_. |
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The portlets that are contained in the War are described using the __wp.PortletS
 | portletName | Name of the portlet as described in the portlet.xml |
 | uniqueName | Unique name for portlet. e.g. com.xebialabs.WelcomePortlet. _Optional_|
 | preferences |Preferences for the portlet described as a key value map. _Optional_. |
+| clones | See _Defining portlet clones_ below. _Optional_. |
+| authLevel | The String representation of the associated auth level. Only used when step-up autentication is enabled. _Optional_. |
 | userAclMapping | See _access permissions_ below. _Optional_. |
 | groupAclMapping | See _access permissions_ below. _Optional_. |
 
@@ -109,10 +111,11 @@ A clone of a portlet is an instance of a portlet with it's own name and specific
 | cloneName | A clone name needs $cloned in the name. If you fully specify the clone name here e.g. welcomePortlet.$cloned.clone1 then it will be used. If only a simple name is used then a full name is generate with portletName and this name, e.g. portletName=welcome-portlet and cloneName = clone1 makes name welcome-portlet.$cloned.clone1. |
 | uniqueName | Unique name for portlet. e.g. com.xebialabs.WelcomePortlet. _Optional_|
 | preferences |Preferences for the portlet described as a key value map. _Optional_. |
-| userAclMapping | See _access permissions_ above. _Optional_. |
-| groupAclMapping | See _access permissions_ above. _Optional_. |
 | defaultLocale | A default locale which describes the portlet. Needs to be in the localedata list |
 | localedata | See _Locale data_ below |
+| authLevel | The String representation of the associated auth level. Only used when step-up autentication is enabled. _Optional_. |
+| userAclMapping | See _access permissions_ above. _Optional_. |
+| groupAclMapping | See _access permissions_ above. _Optional_. |
 
 ### Locale data ###  
 

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -31,7 +31,7 @@
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
         <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletCloneSpec" label="Clones" description="List of portlet clones to register."/>
 
-        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." category="Security" required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -48,7 +48,7 @@
         <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
         <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleDataSpec" label="localedata" description="Locale data, one is mandetory and specified as default."/>
 
-        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." category="Security" required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -86,7 +86,7 @@
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
         <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletClone" label="Clones" description="List of portlet clones to register."/>
 
-        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." category="Security" required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -106,7 +106,7 @@
         <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
         <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleData" label="localedata" description="Locale data, one is mandetory and specified as default."/>
 
-        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." category="Security" required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -31,6 +31,7 @@
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
         <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletCloneSpec" label="Clones" description="List of portlet clones to register."/>
 
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -47,6 +48,7 @@
         <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
         <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleDataSpec" label="localedata" description="Locale data, one is mandetory and specified as default."/>
 
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -84,6 +86,7 @@
         <property name="preferences" description="Portlet preferences." required="false" kind="map_string_string"/>
         <property name="clones" kind="set_of_ci" required="false" as-containment="true" referenced-type="wp.PortletClone" label="Clones" description="List of portlet clones to register."/>
 
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>
@@ -103,6 +106,7 @@
         <property name="defaultlocale" description="Default locale, needs to be in the localedata list." required="true"/>
         <property name="localedata" kind="set_of_ci" required="true" as-containment="true" referenced-type="wp.PortletCloneLocaleData" label="localedata" description="Locale data, one is mandetory and specified as default."/>
 
+        <property name="authLevel" description="The String representation of the associated auth level. Only used when step-up autentication is enabled." required="false"/>
         <property name="userAclMapping" kind="map_string_string" required="false" category="Security"
                   description="List of User ACL mappings of this portlet. Keyed by security level. Value are the subject ids delimited by |. Valid roles are user,privileged user,contributor,editor,manager,delegator,security administrator and administrator">
             <rule type="map-key-regex" pattern="user|privileged user|contributor|editor|manager|delegator|security administrator|administrator"/>

--- a/src/main/resources/was/portal/utils/xmlaccess.py
+++ b/src/main/resources/was/portal/utils/xmlaccess.py
@@ -137,6 +137,10 @@ class XmlAccess(object):
             return
 
         access_control_elm = ET.SubElement(portlet_elm, "access-control")
+
+        if portlet.authLevel:
+            access_control_elm.set("auth-level", portlet.authLevel)
+
         # unmap removed levels
         for level in change_set.removed_items:
             ET.SubElement(access_control_elm, "role", {"actionset": level, "update": "remove"})


### PR DESCRIPTION
Hi,

We found another missing feature, which is step-up authentication which we use in our portal.

I've added the functionality to add auth-level to portlets and portlet clones. It is optional so should not break current functionality.

regards, Maarten