### PR TITLE
Bugfix exception on xmlaccess log line

### DIFF
--- a/src/main/resources/was/portal/utils/xmlaccess.py
+++ b/src/main/resources/was/portal/utils/xmlaccess.py
@@ -66,7 +66,7 @@ class XmlAccess(object):
         else:
             container = deployed.container.cell
 
-        print "Using settings from " + container + " to register XmlAccess"
+        print "Registering XmlAccess with settings from the following container: " + container.name
 
         return XmlAccess(exec_context, container.portalHost, container.wpHome, container.wpAdminUsername, container.wpAdminPassword, container.wpConfigUrl)
 


### PR DESCRIPTION
Hi,

I'm sorry, but I made a booboo last release. Registering fails because of a log line I added. This is the fix.

Can you please quickly accept and release. Because previous version will break every time.

Regards, Maarten