### PR TITLE
Fixed issue related to wrong number of parameters for new_instance_from_container function

### DIFF
--- a/src/main/resources/was/portal/xmlscript/execute-xmlaccess.py
+++ b/src/main/resources/was/portal/xmlscript/execute-xmlaccess.py
@@ -12,7 +12,7 @@ from was.portal.utils.xmlaccess import XmlAccess
 from was.portal.utils.template import TemplateRenderer
 from com.xebialabs.overthere.util import OverthereUtils
 
-xmlaccess = XmlAccess.new_instance_from_container(context, deployed.container.cell, deployed.container.cell.portalHost)
+xmlaccess = XmlAccess.new_instance_from_container(context, deployed)
 
 if is_file:
     req_file = deployed.file.getFile(req_xml)


### PR DESCRIPTION
Fixed issue related to wrong number of parameters for new_instance_from_container method, that should now receive 2 parameters instead of 3. Updated the execute-xmlaccess.py script